### PR TITLE
2nd "cmd not found:" name problem fixed, echo bonjour | cat fixed

### DIFF
--- a/src/03_parse.c
+++ b/src/03_parse.c
@@ -53,13 +53,17 @@ char	**get_args(char **cmd)
 	if (i == split_len(cmd))
 		return (&cmd[i - 1]);
 	arg_count = 0;
-	while (!have_redirec(cmd[++i]))
+	while (cmd[++i] && !have_redirec(cmd[i]))
 		arg_count++;
-	args = ft_calloc((arg_count + 2), sizeof(char *));
+	if (arg_count > 0)
+		args = ft_calloc((arg_count + 2), sizeof(char *));
+	else
+		args = ft_calloc((arg_count + 1), sizeof(char *));
 	j = -1;
 	i = find_cmd_i(cmd) - 1;
-	while (!have_redirec(cmd[++i]))
+	while (cmd[++i] && !have_redirec(cmd[i]))
 		args[++j] = remove_quotes(ft_strdup(cmd[i]));
+	args[++j] = 0;
 	return (args);
 }
 

--- a/src/03_parse_utils.c
+++ b/src/03_parse_utils.c
@@ -15,7 +15,7 @@
 int	have_redirec(char *s)
 {
 	if (!s)
-		return (1);
+		return (0);
 	if (s[0] == '<' || s[0] == '>')
 		return (1);
 	return (0);

--- a/src/03_split_quotes.c
+++ b/src/03_split_quotes.c
@@ -83,6 +83,6 @@ char	**split_quotes(char *cmd)
 			i = next_space_i(cmd, i);
 		}
 	}
-	cmd_split[j] = NULL;
+	cmd_split[cmd_split_count(cmd)] = NULL;
 	return (cmd_split);
 } 

--- a/src/0_main.c
+++ b/src/0_main.c
@@ -69,6 +69,9 @@ static int	prompter(t_ms *ms)
 	return (valid_line(ms->last_line));
 }
 
+// conv_en_var:
+//	- $?
+//	- save_this $var doesnt_save_this
 int	main(int ac, char **av, char **envp)
 {
 	t_ms	*ms;


### PR DESCRIPTION
fixed: split_quotes() was not always NULL terminating its return at the good index, have_redirect() was returning 1 instead of 0 when arg was NULL, NULL terminating get_args() return