### PR TITLE
Vial

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -200,8 +200,8 @@ void	builtin_exit(t_ms *ms, t_cmd *cmd);
 //04_env
 char	**export_env_var(char **args, t_ms *ms);
 char	**unset_env_var(char **args, t_ms *ms);
-
-//04_env_utils.c
+void	export_print(char **envp);
+char	*get_varvalue(char *var);
 char	*get_varname(char *var);
 int		valid_unset(char *var, int err);
 int		valid_export(char *var, int err);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -166,6 +166,7 @@ int		is_pipe(char *s);
 int		have_dbl_redirec(char *s);
 int		have_redirec(char *s);
 char	**split_quotes(char *cmd);
+int		new_i(char *cmd, int i);
 char	**split_cmds(char **cmd);
 void	free_cmds(t_ms *ms);
 t_cmd	*lst_last(t_cmd *head);

--- a/src/01_valid_line.c
+++ b/src/01_valid_line.c
@@ -80,9 +80,9 @@ int	valid_line(char *line)
 	else if (ft_strnstr(line, "<<<<", ft_strlen(line)))
 		error = lineerr_3in;
 	else if (ft_strnstr(line, ">>>>", ft_strlen(line)))
-		error = lineerr_4in;
+		error = lineerr_4out;
 	else if (ft_strnstr(line, ">>>", ft_strlen(line)))
-		error = lineerr_3in;
+		error = lineerr_3out;
 	else if (valid_cmd(line) != 0
 		&& ft_strnstr(line, "|", ft_strlen(line)) != NULL)
 		error = lineerr_pipe;

--- a/src/03_convert_env_var.c
+++ b/src/03_convert_env_var.c
@@ -28,7 +28,7 @@ static char	*get_var_value(char *var)
 	int		i;
 	char	*value;
 
-	i= -1;
+	i = -1;
 	while (var[++i])
 		if (var[i] == '=')
 			break ;
@@ -71,7 +71,7 @@ static char	*replace(char *cmd, int var_i, t_ms *ms)
 	if (alr_exist != -1)
 		varvalue = get_var_value(ms->envp[alr_exist]);
 	else
-	 	varvalue = NULL;
+		varvalue = NULL;
 	new_cmd = ft_strjoin_gnl(new_cmd, varvalue);
 	if (varvalue)
 		free(varvalue);

--- a/src/03_convert_env_var.c
+++ b/src/03_convert_env_var.c
@@ -11,19 +11,7 @@
 /* ************************************************************************** */
 #include "../include/minishell.h"
 
-static char	*get_var_name(char *var)
-{
-	int		i;
-	char	*varname;
-
-	i = 0;
-	while (var[i] && var[i] != ' ' && !is_quote(var[i]) && var[i] != '$')
-		i++;
-	varname = ft_substr(var, 0, i);
-	return (varname);
-}
-
-static char	*get_var_value(char *var)
+char	*get_varvalue(char *var)
 {
 	int		i;
 	char	*value;
@@ -36,6 +24,18 @@ static char	*get_var_value(char *var)
 		return (NULL);
 	value = ft_substr(var, i + 1, ft_strlen(var) - i);
 	return (value);
+}
+
+static char	*get_var_name(char *var)
+{
+	int		i;
+	char	*varname;
+
+	i = 0;
+	while (var[i] && var[i] != ' ' && !is_quote(var[i]) && var[i] != '$')
+		i++;
+	varname = ft_substr(var, 0, i);
+	return (varname);
 }
 
 static int	env_var_i(char *cmd)
@@ -69,7 +69,7 @@ static char	*replace(char *cmd, int var_i, t_ms *ms)
 	varname_len = ft_strlen(varname);
 	alr_exist = already_exist(varname, ms->envp);
 	if (alr_exist != -1)
-		varvalue = get_var_value(ms->envp[alr_exist]);
+		varvalue = get_varvalue(ms->envp[alr_exist]);
 	else
 		varvalue = NULL;
 	new_cmd = ft_strjoin_gnl(new_cmd, varvalue);

--- a/src/03_convert_env_var.c
+++ b/src/03_convert_env_var.c
@@ -17,9 +17,9 @@ static char	*get_var_name(char *var)
 	char	*varname;
 
 	i = 0;
-	while (var[i] && var[i] != ' ' && !is_quote(var[i]))
+	while (var[i] && var[i] != ' ' && !is_quote(var[i]) && var[i] != '$')
 		i++;
-	varname = ft_substr(var, 1, i - 1);
+	varname = ft_substr(var, 0, i);
 	return (varname);
 }
 
@@ -65,7 +65,7 @@ static char	*replace(char *cmd, int var_i, t_ms *ms)
 	int		varname_len;
 
 	new_cmd = ft_substr(cmd, 0, var_i);
-	varname = get_var_name(&cmd[var_i]);
+	varname = get_var_name(&cmd[var_i + 1]);
 	varname_len = ft_strlen(varname);
 	alr_exist = already_exist(varname, ms->envp);
 	if (alr_exist != -1)
@@ -80,8 +80,6 @@ static char	*replace(char *cmd, int var_i, t_ms *ms)
 	return (new_cmd);
 }
 
-// fix this: echo $t1$t2$t3
-// when env var arent spaced out they dont display
 void	conv_env_var(char **cmd, t_ms *ms)
 {
 	int		i;

--- a/src/03_convert_env_var.c
+++ b/src/03_convert_env_var.c
@@ -19,7 +19,7 @@ static char	*get_var_name(char *var)
 	i = 0;
 	while (var[i] && var[i] != ' ' && !is_quote(var[i]))
 		i++;
-	varname = ft_substr(var, 1, i - 1);	
+	varname = ft_substr(var, 1, i - 1);
 	return (varname);
 }
 
@@ -80,6 +80,8 @@ static char	*replace(char *cmd, int var_i, t_ms *ms)
 	return (new_cmd);
 }
 
+// fix this: echo $t1$t2$t3
+// when env var arent spaced out they dont display
 void	conv_env_var(char **cmd, t_ms *ms)
 {
 	int		i;

--- a/src/03_format_line.c
+++ b/src/03_format_line.c
@@ -42,20 +42,13 @@ static int	get_space_count(char *last_line)
 	return (space_count);
 }
 
-// space out the redirections if needed ex: ">out>>out2" = ">out >>out2"
-char	*space_out_redirections(char *last_line)
+static void	fill_new_line(char *n_last_line, char *last_line)
 {
 	int		i;
 	int		j;
 	int		in_quote;
-	int		space_count;
-	char	*n_last_line;
 
 	in_quote = -1;
-	space_count = get_space_count(last_line);
-	if (space_count == 0)
-		return (last_line);
-	n_last_line = malloc(sizeof(char) * ft_strlen(last_line) + space_count + 1);
 	j = 0;
 	i = -1;
 	while (last_line[++i])
@@ -73,6 +66,19 @@ char	*space_out_redirections(char *last_line)
 			n_last_line[j++] = last_line[i];
 	}
 	n_last_line[j] = 0;
+}
+
+// space out the redirections if needed ex: ">out>>out2" = ">out >>out2"
+char	*space_out_redirections(char *last_line)
+{
+	int		space_count;
+	char	*n_last_line;
+
+	space_count = get_space_count(last_line);
+	if (space_count == 0)
+		return (last_line);
+	n_last_line = malloc(sizeof(char) * ft_strlen(last_line) + space_count + 1);
+	fill_new_line(n_last_line, last_line);
 	free(last_line);
 	return (n_last_line);
 }

--- a/src/03_format_line.c
+++ b/src/03_format_line.c
@@ -24,13 +24,21 @@ static int	need_space(char *last_line, int i)
 static int	get_space_count(char *last_line)
 {
 	int	i;
+	int	in_quote;
 	int	space_count;
 
+	in_quote = -1;
 	space_count = 0;
 	i = -1;
 	while (last_line[++i])
-		if (need_space(last_line, i))
+	{
+		if (is_quote(last_line[i]) && in_quote == -1)
+			in_quote = last_line[i];
+		else if (last_line[i] == in_quote && in_quote != -1)
+			in_quote = -1;
+		if (need_space(last_line, i) && in_quote == -1)
 			space_count++;
+	}
 	return (space_count);
 }
 
@@ -39,9 +47,11 @@ char	*space_out_redirections(char *last_line)
 {
 	int		i;
 	int		j;
+	int		in_quote;
 	int		space_count;
 	char	*n_last_line;
 
+	in_quote = -1;
 	space_count = get_space_count(last_line);
 	if (space_count == 0)
 		return (last_line);
@@ -50,7 +60,11 @@ char	*space_out_redirections(char *last_line)
 	i = -1;
 	while (last_line[++i])
 	{
-		if (need_space(last_line, i))
+		if (is_quote(last_line[i]) && in_quote == -1)
+			in_quote = last_line[i];
+		else if (last_line[i] == in_quote && in_quote != -1)
+			in_quote = -1;
+		if (need_space(last_line, i) && in_quote == -1)
 		{
 			n_last_line[j++] = ' ';
 			n_last_line[j++] = last_line[i];

--- a/src/03_parse_utils.c
+++ b/src/03_parse_utils.c
@@ -28,29 +28,45 @@ int	have_dbl_redirec(char *s)
 	return (0);
 }
 
+static int	get_nb_quote(char *s)
+{
+	int	i;
+	int	nb_quote;
+
+	nb_quote = 0;
+	i = -1;
+	while (s[++i])
+	{
+		if (is_quote(s[i]))
+		{
+			i = new_i(s, i) - 1;
+			nb_quote++;
+		}
+	}
+	return (nb_quote);
+}
+
 char	*remove_quotes(char *s)
 {
 	int		i;
 	int		j;
-	int		nb_quotes;
+	int		nb_quote;
+	char	first_quote;
 	char	*new_s;
 
-	if (!s)
-		return (NULL);
-	nb_quotes = 0;
-	i = -1;
-	while (s[++i])
-		if (is_quote(s[i]))
-			nb_quotes++;
-	if (nb_quotes == 0)
+	nb_quote = get_nb_quote(s);
+	if (!nb_quote)
 		return (s);
-	new_s = ft_calloc(ft_strlen(s) - (nb_quotes), sizeof(char));
+	i = 0;
+	while (!is_quote(s[i]))
+		i++;
+	first_quote = s[i];
+	new_s = ft_calloc(ft_strlen(s) - nb_quote + 1, sizeof(char));
 	j = -1;
 	i = -1;
 	while (s[++i])
-		if (!is_quote(s[i]))
+		if (s[i] != first_quote)
 			new_s[++j] = s[i];
-	new_s[++j] = 0;
 	free(s);
 	return (new_s);
 }

--- a/src/03_split_quotes.c
+++ b/src/03_split_quotes.c
@@ -12,14 +12,16 @@
 
 #include "../include/minishell.h"
 
-static int	new_i(char *cmd, int i)
+int	new_i(char *cmd, int i)
 {
-	int	quote_nb;
+	int		quote_nb;
+	char	quote_type;
 
+	quote_type = cmd[i];
 	quote_nb = 1;
 	while (cmd[++i])
 	{
-		if (is_quote(cmd[i]))
+		if (cmd[i] == quote_type)
 			quote_nb++;
 		if ((quote_nb % 2 == 0 && cmd[i] == ' ')
 			|| cmd[i + 1] == '\0')

--- a/src/03_split_quotes.c
+++ b/src/03_split_quotes.c
@@ -30,14 +30,6 @@ int	new_i(char *cmd, int i)
 	return (i);
 }
 
-static int	next_space_i(char *cmd, int i)
-{
-	while (cmd[++i])
-		if (cmd[i] == ' ')
-			break ;
-	return (i);
-}
-
 static int	cmd_split_count(char *cmd)
 {
 	int	i;
@@ -57,6 +49,31 @@ static int	cmd_split_count(char *cmd)
 			count++;
 	}
 	return (count);
+}
+
+static int	parse_block(char **new_cmd, char *cmd, int i)
+{
+	char	in_quote;
+	int		start;
+	int		new_i;
+
+	start = i;
+	in_quote = -1;
+	while (cmd[i])
+	{
+		new_i = i;
+		if (cmd[i] == in_quote)
+			in_quote = -1;
+		else if (is_quote(cmd[i]) && in_quote == -1)
+			in_quote = cmd[i];
+		if (in_quote == -1 && (cmd[i + 1] == ' ' || cmd[i + 1] == '\0'))
+		{
+			*new_cmd = ft_substr(cmd, start, i - start + 1);
+			break ;
+		}
+		i++;
+	}
+	return (new_i);
 }
 
 char	**split_quotes(char *cmd)
@@ -80,10 +97,7 @@ char	**split_quotes(char *cmd)
 		}
 		else if ((i != 0 && cmd[i] != ' ' && cmd[i - 1] == ' ')
 			|| (i == 0 && cmd[i] != ' '))
-		{
-			cmd_split[j++] = ft_substr(cmd, i, next_space_i(cmd, i) - i);
-			i = next_space_i(cmd, i);
-		}
+				i = parse_block(&cmd_split[j++], cmd, i);
 	}
 	cmd_split[cmd_split_count(cmd)] = NULL;
 	return (cmd_split);

--- a/src/03_split_quotes.c
+++ b/src/03_split_quotes.c
@@ -30,10 +30,10 @@ int	new_i(char *cmd, int i)
 	return (i);
 }
 
-static int	next_quote_i(char *cmd, int i)
+static int	next_space_i(char *cmd, int i)
 {
 	while (cmd[++i])
-		if (is_quote(cmd[i]))
+		if (cmd[i] == ' ')
 			break ;
 	return (i);
 }
@@ -81,8 +81,8 @@ char	**split_quotes(char *cmd)
 		else if ((i != 0 && cmd[i] != ' ' && cmd[i - 1] == ' ')
 			|| (i == 0 && cmd[i] != ' '))
 		{
-			cmd_split[j++] = ft_substr(cmd, i, new_i(cmd, next_quote_i(cmd, i)) - i + 2);
-			i = new_i(cmd, next_quote_i(cmd, i)) - i + 1;
+			cmd_split[j++] = ft_substr(cmd, i, next_space_i(cmd, i) - i);
+			i = next_space_i(cmd, i);
 		}
 	}
 	cmd_split[cmd_split_count(cmd)] = NULL;

--- a/src/03_split_quotes.c
+++ b/src/03_split_quotes.c
@@ -30,10 +30,10 @@ int	new_i(char *cmd, int i)
 	return (i);
 }
 
-static int	next_space_i(char *cmd, int i)
+static int	next_quote_i(char *cmd, int i)
 {
 	while (cmd[++i])
-		if (cmd[i] == ' ')
+		if (is_quote(cmd[i]))
 			break ;
 	return (i);
 }
@@ -81,8 +81,8 @@ char	**split_quotes(char *cmd)
 		else if ((i != 0 && cmd[i] != ' ' && cmd[i - 1] == ' ')
 			|| (i == 0 && cmd[i] != ' '))
 		{
-			cmd_split[j++] = ft_substr(cmd, i, next_space_i(cmd, i) - i);
-			i = next_space_i(cmd, i);
+			cmd_split[j++] = ft_substr(cmd, i, new_i(cmd, next_quote_i(cmd, i)) - i + 2);
+			i = new_i(cmd, next_quote_i(cmd, i)) - i + 1;
 		}
 	}
 	cmd_split[cmd_split_count(cmd)] = NULL;

--- a/src/04_builtin_frame.c
+++ b/src/04_builtin_frame.c
@@ -56,7 +56,7 @@ void	builtin_exec(t_ms *ms, t_cmd *cmd)
 	else if (ft_strncmp(cmd->args[0], "unset", ft_strlen("unset") + 1) == 0)
 		ms->envp = unset_env_var(cmd->args, ms);
 	else if (ft_strncmp(cmd->args[0], "env", ft_strlen("env") + 1) == 0)
-		printf("call builtin function %s\n", cmd->args[0]);
+		print_split(ms->envp);
 	else if (ft_strncmp(cmd->args[0], "exit", ft_strlen("exit") + 1) == 0)
 		builtin_exit(ms, cmd);
 	builtin_redirection(ms, cmd, 1);

--- a/src/04_cd.c
+++ b/src/04_cd.c
@@ -12,7 +12,6 @@
 
 #include "../include/minishell.h"
 
-
 static char	**create_args(void)
 {
 	char	path[1000];

--- a/src/04_cd.c
+++ b/src/04_cd.c
@@ -12,8 +12,23 @@
 
 #include "../include/minishell.h"
 
+
+static char	**create_args(void)
+{
+	char	path[1000];
+	char	**args;
+
+	args = ft_calloc(3, sizeof(char *));
+	args[0] = ft_strdup("export");
+	args[1] = ft_strjoin_gnl(ft_strdup("PWD="), getcwd(path, 1000));
+	args[2] = 0;
+	return (args);
+}
+
 static void	access_n_cd(t_ms *ms, t_cmd *cmd, char *newpath)
 {
+	char	**args;
+
 	if (access(newpath, X_OK) == -1)
 	{
 		ms->err_last_child = 1;
@@ -26,7 +41,12 @@ static void	access_n_cd(t_ms *ms, t_cmd *cmd, char *newpath)
 				ERR_OPEN_PERM);
 	}
 	else
+	{
 		chdir(newpath);
+		args = create_args();
+		ms->envp = export_env_var(args, ms);
+		free_split(args);
+	}
 }
 
 static void	cd_0arg(t_ms *ms, t_cmd *cmd)

--- a/src/04_echo.c
+++ b/src/04_echo.c
@@ -11,7 +11,6 @@
 /* ************************************************************************** */
 
 #include "../include/minishell.h"
-#include <stdio.h>
 
 //return 0 if flag and 1 if not
 static int	is_flag_n(char *arg)

--- a/src/04_echo.c
+++ b/src/04_echo.c
@@ -46,7 +46,7 @@ void	builtin_echo(t_ms *ms, t_cmd *cmd)
 		return ;
 	}
 	i = 1;
-	while (is_flag_n(cmd->args[i]) != 1)
+	while (cmd->args[i] && is_flag_n(cmd->args[i]) != 1)
 		i++;
 	if (i > 1)
 		no_skipline = 1;

--- a/src/04_env.c
+++ b/src/04_env.c
@@ -97,7 +97,7 @@ char	**export_env_var(char **args, t_ms *ms)
 	if (split_len(args) == 1)
 	{
 		ms->err_last_child = 1;
-		print_split(ms->envp);
+		export_print(ms->envp);
 		return (ms->envp);
 	}
 	var_count = export_var_count(args, ms->envp);

--- a/src/04_env.c
+++ b/src/04_env.c
@@ -57,8 +57,7 @@ char	**unset_env_var(char **args, t_ms *ms)
 	return (new_envp);
 }
 
-static void	reassign(
-	char **new_envp, char **args)
+static void	reassign(char **new_envp, char **args)
 {
 	int		i;
 	int		arg_i;

--- a/src/04_env_utils.c
+++ b/src/04_env_utils.c
@@ -11,7 +11,23 @@
 /* ************************************************************************** */
 
 #include "../include/minishell.h"
-#include <stdlib.h>
+
+void	export_print(char **envp)
+{
+	int		i;
+	char	*varname;
+	char	*varvalue;
+
+	i = -1;
+	while (envp[++i])
+	{
+		varname = get_varname(envp[i]);
+		varvalue = get_varvalue(envp[i]);
+		printf("declare -x %s=\"%s\"\n", varname, varvalue);
+		free(varname);
+		free(varvalue);
+	}
+}
 
 char	*get_varname(char *var)
 {


### PR DESCRIPTION
split_quotes(); fixed th"is 'is' a te"st = this 'is' a test
space_out_redirections(); was spacing out redirections inside quotes e.g: "<|>"
builtin env added
convert_env_var(); fixed $var$var1 wasnt working
echo -n fixed a segfault
cd builtin fixed: now cd changes the PWD environment variable when switching dir