### PR TITLE
Fix cd in file error, child exit leaks, pwd flag, heredoc signal

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: mraymond <mraymond@student.42quebec.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/29 18:27:32 by gvial             #+#    #+#             */
-/*   Updated: 2022/11/04 09:57:53 by mraymond         ###   ########.fr       */
+/*   Updated: 2022/11/07 10:49:19 by mraymond         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -70,6 +70,7 @@
 # define ERR_BUILT_NOTINPWD ": string not in pwd: "
 # define ERR_BUILT_PDFRULES ": not covered according to subject"
 # define ERR_BUILT_NONNUM ": numeric argument required"
+# define ERR_BUILT_NOTDIR ": Not a directory"
 
 //==============================================================================
 
@@ -172,7 +173,6 @@ int		have_redirec(char *s);
 int		have_dbl_redirec(char *s);
 char	**split_cmds(char **cmd);
 char	**split_quotes(char *cmd);
-t_cmd	*lst_last(t_cmd *head);
 char	*remove_quotes(char *s);
 int		find_cmd_i(char **split);
 char	*isolate_cmd(char *cmd_brut);
@@ -209,12 +209,11 @@ int		valid_export(char *var, int err);
 int		already_exist(char *varname, char **envp);
 char	**export_(char *varname, char *varvalue, t_ms *ms);
 
-// utils
-int		lst_len(t_cmd *head);
-
 //utils2
-void	free_dbl_ptr(void **ptr, int option);
+//void	free_dbl_ptr(void **ptr, int option);
 void	close_all_cmd_fdin_fdout(t_ms *ms);
+t_cmd	*lst_last(t_cmd *head);
+int		lst_len(t_cmd *head);
 
 //EXECUTION---------------------------------------------------------------------
 //05_exec.c
@@ -228,6 +227,7 @@ void	waiting_n_closefd(t_ms *ms);
 void	child_execution(t_ms *ms);
 int		pipe_redirection(t_ms *ms, t_cmd *cmd);
 void	child_exit(t_ms *ms);
+void	child_cleaning(t_ms *ms);
 
 //05_redirection.c
 int		redirection_in(t_ms *ms, t_cmd *cmd);

--- a/src/01_init.c
+++ b/src/01_init.c
@@ -6,13 +6,13 @@
 /*   By: mraymond <mraymond@student.42quebec.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/10/05 09:28:21 by mraymond          #+#    #+#             */
-/*   Updated: 2022/10/24 10:35:16 by mraymond         ###   ########.fr       */
+/*   Updated: 2022/11/07 09:18:35 by mraymond         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../include/minishell.h"
 
-//if init_workpath = 1, take the pwd working_path
+// Set the line prompter message (ms-> actual file $>)
 void	fill_line_prompter(t_ms *ms)
 {
 	int		i_last_dir;
@@ -29,6 +29,7 @@ void	fill_line_prompter(t_ms *ms)
 		PROMPTER_END, ft_strlen(PROMPTER_END) + 1);
 }
 
+//Initialize all the ms values
 void	ms_init(t_ms *ms, char **envp)
 {
 	char	*shlvl;
@@ -55,6 +56,7 @@ void	ms_init(t_ms *ms, char **envp)
 	ms->std_fd[1] = dup(1);
 }
 
+// free and reset all the ms->values for next line commands
 void	ms_reset(t_ms *ms)
 {
 	if (ms->last_line)
@@ -75,7 +77,8 @@ void	ms_reset(t_ms *ms)
 	ms->skip_cmd = 0;
 }
 
-//put 1 in arg to erase;
+/* Malloc and/or return or free ms
+** put 1 in arg to free*/
 t_ms	*get_ms(int erase)
 {
 	static t_ms	*ms = NULL;

--- a/src/01_valid_line.c
+++ b/src/01_valid_line.c
@@ -6,15 +6,13 @@
 /*   By: mraymond <mraymond@student.42quebec.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/10/05 15:00:25 by mraymond          #+#    #+#             */
-/*   Updated: 2022/10/18 14:44:15 by mraymond         ###   ########.fr       */
+/*   Updated: 2022/11/07 09:29:16 by mraymond         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../include/minishell.h"
 
-/*return 0 if something each side of pipe. 
-Else return 1
-*/
+/*return 0 if something each side of pipe Else return 1*/
 static int	valid_cmd(char *line)
 {
 	int	i;
@@ -43,9 +41,7 @@ static int	valid_cmd(char *line)
 	return (0);
 }
 
-/*return 0 if quotes closed
-Else return 1
-*/
+/*Return 0 if quotes closed Else return 1*/
 static int	valid_quotes(char *line)
 {
 	int	i;
@@ -67,9 +63,9 @@ static int	valid_quotes(char *line)
 	return (1);
 }
 
-/*return 0 if valid line
-Else return (1)
-*/
+/* Check for unclosed quotes / empty command / bad redirection
+** return 0 if it's a valid line 
+** else print error_message and return error_number*/
 int	valid_line(char *line)
 {
 	int	error;
@@ -93,6 +89,7 @@ int	valid_line(char *line)
 	return (print_line_err(error));
 }
 
+/* print the error message accordingly of the error_number*/
 int	print_line_err(int error)
 {
 	if (error > 0)
@@ -120,6 +117,8 @@ int	print_line_err(int error)
 	return (error);
 }
 
+/* conversion error valid line to good ms->err_last_child ($?)
+** cannot be at the exit of valid line because of the 0 that return validline*/
 int	valid_line_error_conversion(int valid_line_return)
 {
 	if (valid_line_return == lineerr_quote)

--- a/src/03_utils2.c
+++ b/src/03_utils2.c
@@ -6,12 +6,13 @@
 /*   By: mraymond <mraymond@student.42quebec.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/10/07 17:37:15 by mraymond          #+#    #+#             */
-/*   Updated: 2022/10/19 10:17:51 by mraymond         ###   ########.fr       */
+/*   Updated: 2022/11/07 09:32:50 by mraymond         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../include/minishell.h"
 
+/*
 //option 0: with double ptr -- 1:only inside
 void	free_dbl_ptr(void **ptr, int option)
 {
@@ -26,7 +27,9 @@ void	free_dbl_ptr(void **ptr, int option)
 			free(ptr);
 	}
 }
+*/
 
+/* close all fd in all ms->cmds->fildes*/
 void	close_all_cmd_fdin_fdout(t_ms *ms)
 {
 	t_cmd	*cmd;
@@ -43,6 +46,7 @@ void	close_all_cmd_fdin_fdout(t_ms *ms)
 	}
 }
 
+/* return last node of the head list*/
 t_cmd	*lst_last(t_cmd *head)
 {
 	if (!head)
@@ -52,6 +56,7 @@ t_cmd	*lst_last(t_cmd *head)
 	return (head);
 }
 
+/* return the len of head list*/
 int	lst_len(t_cmd *head)
 {
 	int	len;

--- a/src/04_builtin_frame.c
+++ b/src/04_builtin_frame.c
@@ -6,13 +6,13 @@
 /*   By: mraymond <mraymond@student.42quebec.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/10/19 08:57:42 by mraymond          #+#    #+#             */
-/*   Updated: 2022/10/20 14:20:34 by mraymond         ###   ########.fr       */
+/*   Updated: 2022/11/07 10:26:04 by mraymond         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../include/minishell.h"
 
-//check if its a builtin
+// if cmd->args[0] is a builtin -> return 1 else return 0
 int	builtin_checker(t_cmd *cmd)
 {
 	if (!cmd->args)
@@ -28,6 +28,7 @@ int	builtin_checker(t_cmd *cmd)
 	return (0);
 }
 
+// Plus certain de sa necessite mais ca marche???
 static void	builtin_redirection(t_ms *ms, t_cmd *cmd, int in_out)
 {
 	if (in_out == 0)
@@ -42,6 +43,7 @@ static void	builtin_redirection(t_ms *ms, t_cmd *cmd, int in_out)
 	}
 }
 
+// Select and execute the good builtin 
 void	builtin_exec(t_ms *ms, t_cmd *cmd)
 {
 	builtin_redirection(ms, cmd, 0);

--- a/src/04_cd.c
+++ b/src/04_cd.c
@@ -6,12 +6,13 @@
 /*   By: mraymond <mraymond@student.42quebec.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/10/19 14:48:08 by mraymond          #+#    #+#             */
-/*   Updated: 2022/10/21 13:00:06 by mraymond         ###   ########.fr       */
+/*   Updated: 2022/11/07 10:19:25 by mraymond         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../include/minishell.h"
 
+// set envp after good cd
 char	**export_(char *varname, char *varvalue, t_ms *ms)
 {
 	char	**args;
@@ -26,17 +27,23 @@ char	**export_(char *varname, char *varvalue, t_ms *ms)
 	return (new_envp);
 }
 
+/* check validity of cd path
+** if valid: record oldpwd & cd & record pwd
+** else print error message */
 static void	access_n_cd(t_ms *ms, t_cmd *cmd, char *newpath)
 {
 	char	path[1000];
 
-	if (access(newpath, X_OK) == -1)
+	if (access(newpath, X_OK) == -1 || am_i_this(newpath, 'd', 0, 0) == 0)
 	{
 		ms->err_last_child = 1;
 		dup2(ms->std_fd[1], 1);
 		if (access(newpath, F_OK) == -1)
 			printf("%s%s%s%s%s\n", "ms: ", cmd->args[0], ": ", newpath,
 				ERR_OPEN_NOSUCH);
+		else if (am_i_this(newpath, 'f', 0, 0) == 1)
+			printf("%s%s%s%s%s\n", "ms: ", cmd->args[0], ": ", newpath,
+				ERR_BUILT_NOTDIR);
 		else
 			printf("%s%s%s%s%s\n", "ms: ", cmd->args[0], ": ", newpath,
 				ERR_OPEN_PERM);
@@ -49,6 +56,7 @@ static void	access_n_cd(t_ms *ms, t_cmd *cmd, char *newpath)
 	}
 }
 
+/* if cd no args, cd in home. If home not found, cd to Users dir*/
 static void	cd_0arg(t_ms *ms, t_cmd *cmd)
 {
 	char	*homepath;
@@ -67,6 +75,7 @@ static void	cd_0arg(t_ms *ms, t_cmd *cmd)
 		access_n_cd(ms, cmd, "/Users");
 }
 
+// reset err_last_child, check nb arg and cd
 void	builtin_cd(t_ms *ms, t_cmd *cmd)
 {	
 	int	nb_args;

--- a/src/04_echo.c
+++ b/src/04_echo.c
@@ -6,13 +6,15 @@
 /*   By: mraymond <mraymond@student.42quebec.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/10/20 12:03:18 by mraymond          #+#    #+#             */
-/*   Updated: 2022/10/25 12:11:34 by mraymond         ###   ########.fr       */
+/*   Updated: 2022/11/07 10:34:08 by mraymond         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../include/minishell.h"
 
-//return 0 if flag and 1 if not
+/*return 0 if flag and 1 if not
+** check if valid flag -n or -nn or -nnn... are valids
+*/
 static int	is_flag_n(char *arg)
 {
 	int	i;
@@ -32,6 +34,10 @@ static int	is_flag_n(char *arg)
 	return (val_line);
 }
 
+/* return \n if no arg
+** skip all -n flag
+** if not last arg, add a space
+*/
 void	builtin_echo(t_ms *ms, t_cmd *cmd)
 {
 	int	no_skipline;

--- a/src/04_exit.c
+++ b/src/04_exit.c
@@ -6,7 +6,7 @@
 /*   By: mraymond <mraymond@student.42quebec.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/10/20 12:51:26 by mraymond          #+#    #+#             */
-/*   Updated: 2022/10/21 15:05:45 by mraymond         ###   ########.fr       */
+/*   Updated: 2022/11/07 10:40:09 by mraymond         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,6 +29,7 @@ static int	ft_is_str_digit(char *str)
 	return (0);
 }
 
+// return strlen of long long
 static int	ll_len_limit(void)
 {
 	long long	pow10;
@@ -44,6 +45,7 @@ static int	ll_len_limit(void)
 	return (llmax_len + 1);
 }
 
+//convert str to long long
 static long long	ft_atoll(char *str)
 {
 	long long	val;
@@ -65,6 +67,7 @@ static long long	ft_atoll(char *str)
 	return (val);
 }
 
+//convert str to 0 to 255 int
 static int	llstr_modulo_256(char *str)
 {
 	long long	val;
@@ -77,6 +80,11 @@ static int	llstr_modulo_256(char *str)
 	return (modulo);
 }
 
+/* Message err if more than 1 arg
+** If arg is not num, return message err
+** if arg is num, convert the number to 0 to 255 number
+** only exit if not in child
+*/
 void	builtin_exit(t_ms *ms, t_cmd *cmd)
 {
 	if (cmd->args[1])

--- a/src/04_pwd.c
+++ b/src/04_pwd.c
@@ -6,22 +6,23 @@
 /*   By: mraymond <mraymond@student.42quebec.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/10/19 14:41:07 by mraymond          #+#    #+#             */
-/*   Updated: 2022/10/20 14:24:10 by mraymond         ###   ########.fr       */
+/*   Updated: 2022/11/07 10:54:11 by mraymond         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../include/minishell.h"
 
+//print pwd except if flag used
 void	builtin_pwd(t_ms *ms, t_cmd *cmd)
 {
 	char	path[1000];
 
 	ms->err_last_child = 0;
-	if (cmd->args[1])
+	if (cmd->args[1] && cmd->args[1][0] == '-' && cmd->args[1][1] != '\0')
 	{
 		ms->err_last_child = 1;
 		dup2(ms->std_fd[1], 1);
-		printf("%s%s\n", cmd->args[0], ERR_BUILT_TOOMANYARGS);
+		printf("%s%s%s\n", cmd->args[0], ": usage", ERR_BUILT_PDFRULES);
 	}
 	else
 		printf("%s\n", getcwd(path, 1000));

--- a/src/05_exec.c
+++ b/src/05_exec.c
@@ -6,12 +6,16 @@
 /*   By: mraymond <mraymond@student.42quebec.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/29 18:28:01 by gvial             #+#    #+#             */
-/*   Updated: 2022/11/04 09:56:25 by mraymond         ###   ########.fr       */
+/*   Updated: 2022/11/07 11:13:13 by mraymond         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../include/minishell.h"
 
+/* Set nb_cmd and malloc child_id
+** set the signal to execution mode
+** if just one cmd and its a built in, execute builtin in main process
+** else create process for each process*/
 void	exec(t_ms *ms)
 {
 	ms->nb_cmd = lst_len(ms->cmds);
@@ -33,6 +37,7 @@ void	exec(t_ms *ms)
 	}
 }
 
+// Create pipe for link between cmd and fill ms->pipe
 void	fd_allocation(t_ms *ms)
 {
 	int	i;
@@ -50,6 +55,7 @@ void	fd_allocation(t_ms *ms)
 	}
 }
 
+//Fill cmd->fildes with redirection or ms->pipe. Free ms-pipe
 void	fd_redirection(t_ms *ms)
 {
 	int		cmd_index;
@@ -78,6 +84,7 @@ void	fd_redirection(t_ms *ms)
 	close_n_free_mspipe(ms);
 }
 
+// Loop of child process + fill ms->child_id with process id 
 void	child_creation(t_ms *ms)
 {
 	int		process_id;

--- a/src/05_exec_utils.c
+++ b/src/05_exec_utils.c
@@ -6,13 +6,13 @@
 /*   By: mraymond <mraymond@student.42quebec.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/10/12 13:21:46 by mraymond          #+#    #+#             */
-/*   Updated: 2022/11/04 09:57:46 by mraymond         ###   ########.fr       */
+/*   Updated: 2022/11/07 11:07:28 by mraymond         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../include/minishell.h"
 
-//close all pipe open (but not 0 and 1)
+//close all ms->pipe open (except ms->pipe[0] and ms->pipe[last])
 void	close_n_free_mspipe(t_ms *ms)
 {
 	int	i;
@@ -24,6 +24,7 @@ void	close_n_free_mspipe(t_ms *ms)
 	ms->pipe = NULL;
 }
 
+// check if fd open and keep errno if close return error
 void	closefd_ifopen(int fd)
 {
 	struct stat	stat_buffer;
@@ -35,6 +36,7 @@ void	closefd_ifopen(int fd)
 	errno = temp_err;
 }
 
+//return the pointer of cmd accordingly of the index
 t_cmd	*cmd_lst_index(t_ms *ms, int cmd_index)
 {
 	int		i;
@@ -47,6 +49,7 @@ t_cmd	*cmd_lst_index(t_ms *ms, int cmd_index)
 	return (temp);
 }
 
+// return index of a child process using table ms->child_id
 int	child_process_to_index(t_ms *ms, int waitpid_return)
 {
 	int	i;
@@ -59,6 +62,8 @@ int	child_process_to_index(t_ms *ms, int waitpid_return)
 	return (i);
 }
 
+/* If terminal cursor x position is not 1, write \n
+*/
 void	if_xnot0_skipline(void)
 {
 	int				i;

--- a/src/0_main.c
+++ b/src/0_main.c
@@ -6,7 +6,7 @@
 /*   By: mraymond <mraymond@student.42quebec.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/29 18:27:46 by gvial             #+#    #+#             */
-/*   Updated: 2022/10/24 11:56:21 by mraymond         ###   ########.fr       */
+/*   Updated: 2022/11/07 09:13:46 by mraymond         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -50,6 +50,10 @@ void	print_cmd_lst(t_cmd *head)
 }
 /************^^^^^testing functions^^^^^************/
 
+/* reset signal et ms
+** gestion du ctrl d et champs vide
+** add_history
+** return if a valid line*/
 static int	prompter(t_ms *ms)
 {
 	ms->signal = 0;
@@ -95,6 +99,10 @@ int	main(int ac, char **av, char **envp)
 	return (0);
 }
 
+/* Keep exit status
+** Write exit
+**clean and close everything
+** exit status*/
 void	history_clear_n_exit(t_ms *ms)
 {
 	int	status;


### PR DESCRIPTION
- Add comments
- cd show good message when try to cd in file
- child_exit now free ms and envp
- pwd with flag now show not cover subject message
- pwd with multiple args now show path (Before showed error message too many arg "zsh style")
- heredoc signal and status bug fix (Bug: if error 1 on previous command, heredoc didn't worked)